### PR TITLE
Update travis for using luajit correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   matrix:
     - LUA=lua5.1
     - LUA=lua5.2
-    - LUA=luajit-2.0.0-beta9
+    - LUA=luajit
 
 addons:
   apt:


### PR DESCRIPTION
This is uneeded to specify luajit version so remove it.